### PR TITLE
Added alpine image for 4.2.1

### DIFF
--- a/4.2.1-alpine/Dockerfile
+++ b/4.2.1-alpine/Dockerfile
@@ -1,0 +1,56 @@
+FROM golang:1.9-alpine3.6 as go
+
+# Setup the Environment
+ENV GOPATH=/root/go \
+    PATH=${PATH}:/usr/local/go/bin:/root/go/bin \
+    VERSION_TAG=v4.2.1 \
+    LANG=C.UTF-8
+
+# Install Build Deps
+RUN apk add --no-cache git bash gcc alpine-sdk build-base
+
+# Build the rqlite binary
+RUN mkdir -p /root/dist ${GOPATH} \
+    && cd ${GOPATH} \
+    && mkdir -p src/github.com/rqlite \
+    && cd src/github.com/rqlite \
+    && git clone https://github.com/rqlite/rqlite \
+    && cd rqlite \
+    && git checkout -b alpine-${VERSION_TAG} tags/${VERSION_TAG} \
+    && branch=`git rev-parse --abbrev-ref HEAD` \
+    && commit=`git rev-parse HEAD` \
+    && buildtime=`date +%Y-%m-%dT%T%z` \
+    && go get -d ./... \
+    && go install -ldflags="-X main.version=${VERSION_TAG} -X main.branch=$branch -X main.commit=$commit -X main.buildtime=$buildtime" ./...
+
+# Real Build Now
+FROM alpine:3.6
+
+# Add real maintainer
+MAINTAINER Philip O'Toole <philip.otoole@yahoo.com>
+
+# Setup the Environment
+ENV GOPATH=/root/go \
+    PATH=${PATH}:/usr/local/go/bin:/root/go/bin \
+    LANG=C.UTF-8 \
+    RQLITE_VERSION=4.2.1
+
+# Upgrade (just in case there are security updates)
+RUN apk update -v \
+    && apk upgrade -v --no-cache
+
+# Copy Assets from Go build
+COPY --from=go /root/go/bin/rqlited /bin/rqlited
+COPY --from=go /root/go/bin/rqlite /bin/rqlite
+COPY docker-entrypoint.sh /bin/docker-entrypoint.sh
+
+# Create Volume
+RUN mkdir -p /rqlite/file
+VOLUME /rqlite/file
+
+# Expose Ports
+EXPOSE 4001 4002
+
+ENTRYPOINT [ "docker-entrypoint.sh" ]
+
+CMD ["rqlited", "-http-addr", "0.0.0.0:4001", "-raft-addr", "0.0.0.0:4002", "/rqlite/file/data"]

--- a/4.2.1-alpine/docker-entrypoint.sh
+++ b/4.2.1-alpine/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# User wants to override options, so merge with defaults.
+if [ "${1:0:1}" = '-' ]; then
+        set -- rqlited -http-addr 0.0.0.0:4001 -raft-addr 0.0.0.0:4002 $@ /rqlite/file/data
+fi
+
+exec "$@"


### PR DESCRIPTION
Added alpine image for 4.2.1 :: Build log pasted below

```
$ docker build -t rqlite/rqlite:4.2.1-alpine 4.2.1-alpine/
Sending build context to Docker daemon  4.608kB
Step 1/16 : FROM golang:1.9-alpine3.6 as go
 ---> 9e3f14138abd
Step 2/16 : ENV GOPATH /root/go PATH ${PATH}:/usr/local/go/bin:/root/go/bin VERSION_TAG v4.2.1 LANG C.UTF-8
 ---> Using cache
 ---> d0bb5e691282
Step 3/16 : RUN apk add --no-cache git bash gcc alpine-sdk build-base
 ---> Using cache
 ---> b6e908b64b39
Step 4/16 : RUN mkdir -p /root/dist ${GOPATH}     && cd ${GOPATH}     && mkdir -p src/github.com/rqlite     && cd src/github.com/rqlite     && git clone https://github.com/rqlite/rqlite     && cd rqlite     && git checkout -b alpine-${VERSION_TAG} tags/${VERSION_TAG}     && branch=`git rev-parse --abbrev-ref HEAD`     && commit=`git rev-parse HEAD`     && buildtime=`date +%Y-%m-%dT%T%z`     && go get -d ./...     && go install -ldflags="-X main.version=${VERSION_TAG} -X main.branch=$branch -X main.commit=$commit -X main.buildtime=$buildtime" ./...
 ---> Running in 235d28eb97c0
Cloning into 'rqlite'...
Switched to a new branch 'alpine-v4.2.1'
 ---> 0540f268fa36
Removing intermediate container 235d28eb97c0
Step 5/16 : FROM alpine:3.6
 ---> 7328f6f8b418
Step 6/16 : MAINTAINER Philip O'Toole <philip.otoole@yahoo.com>
 ---> Using cache
 ---> c927e9eb3a83
Step 7/16 : ENV GOPATH /root/go PATH ${PATH}:/usr/local/go/bin:/root/go/bin LANG C.UTF-8 RQLITE_VERSION 4.2.1
 ---> Using cache
 ---> 8fc24a8296e0
Step 8/16 : RUN apk update -v     && apk upgrade -v --no-cache
 ---> Using cache
 ---> 34bfcd8db064
Step 9/16 : COPY --from=go /root/go/bin/rqlited /bin/rqlited
 ---> 80011c3147a9
Step 10/16 : COPY --from=go /root/go/bin/rqlite /bin/rqlite
 ---> e9b9ca59dbca
Step 11/16 : COPY docker-entrypoint.sh /bin/docker-entrypoint.sh
 ---> 54372ec52b0a
Step 12/16 : RUN mkdir -p /rqlite/file
 ---> Running in 59155ff80e50
 ---> a649ad5caad9
Removing intermediate container 59155ff80e50
Step 13/16 : VOLUME /rqlite/file
 ---> Running in 0f6605b11a71
 ---> 4b6c48e4f753
Removing intermediate container 0f6605b11a71
Step 14/16 : EXPOSE 4001 4002
 ---> Running in 09c2808b9fab
 ---> cd63943c1a93
Removing intermediate container 09c2808b9fab
Step 15/16 : ENTRYPOINT docker-entrypoint.sh
 ---> Running in 3a6c0e196940
 ---> 6141426f1165
Removing intermediate container 3a6c0e196940
Step 16/16 : CMD rqlited -http-addr 0.0.0.0:4001 -raft-addr 0.0.0.0:4002 /rqlite/file/data
 ---> Running in 6d3128dbd291
 ---> 9b8599dd500f
Removing intermediate container 6d3128dbd291
Successfully built 9b8599dd500f
Successfully tagged rqlite/rqlite:4.2.1-alpine
```