### PR TITLE
Added alpine image for 4.2.2

### DIFF
--- a/4.2.2-alpine/Dockerfile
+++ b/4.2.2-alpine/Dockerfile
@@ -1,0 +1,56 @@
+FROM golang:1.9-alpine3.6 as go
+
+# Setup the Environment
+ENV GOPATH=/root/go \
+    PATH=${PATH}:/usr/local/go/bin:/root/go/bin \
+    VERSION_TAG=v4.2.2 \
+    LANG=C.UTF-8
+
+# Install Build Deps
+RUN apk add --no-cache git bash gcc alpine-sdk build-base
+
+# Build the rqlite binary
+RUN mkdir -p /root/dist ${GOPATH} \
+    && cd ${GOPATH} \
+    && mkdir -p src/github.com/rqlite \
+    && cd src/github.com/rqlite \
+    && git clone https://github.com/rqlite/rqlite \
+    && cd rqlite \
+    && git checkout -b alpine-${VERSION_TAG} tags/${VERSION_TAG} \
+    && branch=`git rev-parse --abbrev-ref HEAD` \
+    && commit=`git rev-parse HEAD` \
+    && buildtime=`date +%Y-%m-%dT%T%z` \
+    && go get -d ./... \
+    && go install -ldflags="-X main.version=${VERSION_TAG} -X main.branch=$branch -X main.commit=$commit -X main.buildtime=$buildtime" ./...
+
+# Real Build Now
+FROM alpine:3.6
+
+# Add real maintainer
+MAINTAINER Philip O'Toole <philip.otoole@yahoo.com>
+
+# Setup the Environment
+ENV GOPATH=/root/go \
+    PATH=${PATH}:/usr/local/go/bin:/root/go/bin \
+    LANG=C.UTF-8 \
+    RQLITE_VERSION=4.2.2
+
+# Upgrade (just in case there are security updates)
+RUN apk update -v \
+    && apk upgrade -v --no-cache
+
+# Copy Assets from Go build
+COPY --from=go /root/go/bin/rqlited /bin/rqlited
+COPY --from=go /root/go/bin/rqlite /bin/rqlite
+COPY docker-entrypoint.sh /bin/docker-entrypoint.sh
+
+# Create Volume
+RUN mkdir -p /rqlite/file
+VOLUME /rqlite/file
+
+# Expose Ports
+EXPOSE 4001 4002
+
+ENTRYPOINT [ "docker-entrypoint.sh" ]
+
+CMD ["rqlited", "-http-addr", "0.0.0.0:4001", "-raft-addr", "0.0.0.0:4002", "/rqlite/file/data"]

--- a/4.2.2-alpine/docker-entrypoint.sh
+++ b/4.2.2-alpine/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# User wants to override options, so merge with defaults.
+if [ "${1:0:1}" = '-' ]; then
+        set -- rqlited -http-addr 0.0.0.0:4001 -raft-addr 0.0.0.0:4002 $@ /rqlite/file/data
+fi
+
+exec "$@"


### PR DESCRIPTION
Sorry for the delay in this.  4.2.2 snuck by me :-)

Here's the output from the build:
```
$ docker build -t rqlite/rqlite-alpine:4.2.2 ./4.2.2-alpine
Sending build context to Docker daemon  4.608kB
Step 1/16 : FROM golang:1.9-alpine3.6 as go
 ---> 9e3f14138abd
Step 2/16 : ENV GOPATH=/root/go     PATH=${PATH}:/usr/local/go/bin:/root/go/bin     VERSION_TAG=v4.2.2     LANG=C.UTF-8
 ---> Running in c2c642e10fdb
Removing intermediate container c2c642e10fdb
 ---> a64ce7fdfc82
Step 3/16 : RUN apk add --no-cache git bash gcc alpine-sdk build-base
 ---> Running in ece14a9c2d56
fetch http://dl-cdn.alpinelinux.org/alpine/v3.6/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.6/community/x86_64/APKINDEX.tar.gz
(1/60) Installing fakeroot (1.21-r1)
(2/60) Installing sudo (1.8.19_p2-r0)
(3/60) Installing libcap (2.25-r1)
(4/60) Installing pax-utils (1.2.2-r0)
(5/60) Installing libressl2.5-libtls (2.5.5-r0)
(6/60) Installing libressl (2.5.5-r0)
(7/60) Installing libattr (2.4.47-r6)
(8/60) Installing attr (2.4.47-r6)
(9/60) Installing tar (1.29-r1)
(10/60) Installing pkgconf (1.3.7-r0)
(11/60) Installing patch (2.7.5-r1)
(12/60) Installing libgcc (6.3.0-r4)
(13/60) Installing libstdc++ (6.3.0-r4)
(14/60) Installing lzip (1.19-r0)
(15/60) Installing libssh2 (1.8.0-r1)
(16/60) Installing libcurl (7.57.0-r0)
(17/60) Installing curl (7.57.0-r0)
(18/60) Installing abuild (3.0.0_rc2-r8)
Executing abuild-3.0.0_rc2-r8.pre-install
(19/60) Installing binutils-libs (2.28-r3)
(20/60) Installing binutils (2.28-r3)
(21/60) Installing gmp (6.1.2-r0)
(22/60) Installing isl (0.17.1-r0)
(23/60) Installing libgomp (6.3.0-r4)
(24/60) Installing libatomic (6.3.0-r4)
(25/60) Installing mpfr3 (3.1.5-r0)
(26/60) Installing mpc1 (1.0.3-r0)
(27/60) Installing gcc (6.3.0-r4)
(28/60) Installing musl-dev (1.1.16-r14)
(29/60) Installing libc-dev (0.7.1-r0)
(30/60) Installing g++ (6.3.0-r4)
(31/60) Installing make (4.2.1-r0)
(32/60) Installing fortify-headers (0.8-r0)
(33/60) Installing build-base (0.5-r0)
(34/60) Installing expat (2.2.0-r1)
(35/60) Installing pcre (8.41-r0)
(36/60) Installing git (2.13.5-r0)
(37/60) Installing xz-libs (5.2.3-r0)
(38/60) Installing lzo (2.10-r0)
(39/60) Installing squashfs-tools (4.3-r3)
(40/60) Installing libburn (1.4.6-r0)
(41/60) Installing ncurses-terminfo-base (6.0_p20170930-r0)
(42/60) Installing ncurses-terminfo (6.0_p20170930-r0)
(43/60) Installing ncurses-libs (6.0_p20170930-r0)
(44/60) Installing libedit (20170329.3.1-r2)
(45/60) Installing libacl (2.2.52-r3)
(46/60) Installing libisofs (1.4.6-r0)
(47/60) Installing libisoburn (1.4.6-r0)
(48/60) Installing xorriso (1.4.6-r0)
(49/60) Installing acct (6.6.3-r0)
(50/60) Installing lddtree (1.26-r0)
(51/60) Installing libuuid (2.28.2-r2)
(52/60) Installing libblkid (2.28.2-r2)
(53/60) Installing device-mapper-libs (2.02.168-r3)
(54/60) Installing cryptsetup-libs (1.7.5-r0)
(55/60) Installing kmod (23-r1)
(56/60) Installing mkinitfs (3.1.0-r3)
Executing mkinitfs-3.1.0-r3.post-install
(57/60) Installing mtools (4.0.18-r1)
(58/60) Installing alpine-sdk (0.5-r0)
(59/60) Installing readline (6.3.008-r5)
(60/60) Installing bash (4.3.48-r1)
Executing bash-4.3.48-r1.post-install
Executing busybox-1.26.2-r7.trigger
Executing ca-certificates-20161130-r2.trigger
OK: 195 MiB in 72 packages
Removing intermediate container ece14a9c2d56
 ---> 8460b903e5a8
Step 4/16 : RUN mkdir -p /root/dist ${GOPATH}     && cd ${GOPATH}     && mkdir -p src/github.com/rqlite     && cd src/github.com/rqlite     && git clone https://github.com/rqlite/rqlite     && cd rqlite     && git checkout -b alpine-${VERSION_TAG} tags/${VERSION_TAG}     && branch=`git rev-parse --abbrev-ref HEAD`     && commit=`git rev-parse HEAD`     && buildtime=`date +%Y-%m-%dT%T%z`     && go get -d ./...     && go install -ldflags="-X main.version=${VERSION_TAG} -X main.branch=$branch -X main.commit=$commit -X main.buildtime=$buildtime" ./...
 ---> Running in ec0d0b870c9c
Cloning into 'rqlite'...
Switched to a new branch 'alpine-v4.2.2'
Removing intermediate container ec0d0b870c9c
 ---> 49ffc13c7adc
Step 5/16 : FROM alpine:3.6
 ---> 7328f6f8b418
Step 6/16 : MAINTAINER Philip O'Toole <philip.otoole@yahoo.com>
 ---> Using cache
 ---> c927e9eb3a83
Step 7/16 : ENV GOPATH=/root/go     PATH=${PATH}:/usr/local/go/bin:/root/go/bin     LANG=C.UTF-8     RQLITE_VERSION=4.2.2
 ---> Running in 2b9137c71c8a
Removing intermediate container 2b9137c71c8a
 ---> 1cfa43b568ce
Step 8/16 : RUN apk update -v     && apk upgrade -v --no-cache
 ---> Running in 6e1faf837471
fetch http://dl-cdn.alpinelinux.org/alpine/v3.6/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.6/community/x86_64/APKINDEX.tar.gz
v3.6.2-243-g9d95c23115 [http://dl-cdn.alpinelinux.org/alpine/v3.6/main]
v3.6.2-242-g41c32d5e5e [http://dl-cdn.alpinelinux.org/alpine/v3.6/community]
OK: 8443 distinct packages available
fetch http://dl-cdn.alpinelinux.org/alpine/v3.6/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.6/community/x86_64/APKINDEX.tar.gz
Upgrading critical system libraries and apk-tools:
(1/1) Upgrading apk-tools (2.7.2-r0 -> 2.7.5-r0)
Executing busybox-1.26.2-r5.trigger
Continuing the upgrade transaction with new apk-tools:
fetch http://dl-cdn.alpinelinux.org/alpine/v3.6/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.6/community/x86_64/APKINDEX.tar.gz
(1/5) Upgrading musl (1.1.16-r10 -> 1.1.16-r14)
(2/5) Upgrading busybox (1.26.2-r5 -> 1.26.2-r9)
Executing busybox-1.26.2-r9.post-upgrade
(3/5) Upgrading libressl2.5-libcrypto (2.5.4-r0 -> 2.5.5-r0)
(4/5) Upgrading libressl2.5-libssl (2.5.4-r0 -> 2.5.5-r0)
(5/5) Upgrading musl-utils (1.1.16-r10 -> 1.1.16-r14)
Executing busybox-1.26.2-r9.trigger
OK: 11 packages, 83 dirs, 68 files, 4 MiB
Removing intermediate container 6e1faf837471
 ---> 5d734e57ff1d
Step 9/16 : COPY --from=go /root/go/bin/rqlited /bin/rqlited
 ---> 57a09d8d030c
Step 10/16 : COPY --from=go /root/go/bin/rqlite /bin/rqlite
 ---> 12a0aad62ace
Step 11/16 : COPY docker-entrypoint.sh /bin/docker-entrypoint.sh
 ---> 72325e38c2f2
Step 12/16 : RUN mkdir -p /rqlite/file
 ---> Running in ed3b67fb8dfe
Removing intermediate container ed3b67fb8dfe
 ---> b116bc1f0528
Step 13/16 : VOLUME /rqlite/file
 ---> Running in 1b5a7bc9f9ff
Removing intermediate container 1b5a7bc9f9ff
 ---> c9e50e4b1988
Step 14/16 : EXPOSE 4001 4002
 ---> Running in 8301aaf85531
Removing intermediate container 8301aaf85531
 ---> 9ce3baa35a09
Step 15/16 : ENTRYPOINT [ "docker-entrypoint.sh" ]
 ---> Running in 18bb348d21b0
Removing intermediate container 18bb348d21b0
 ---> 0fb18cf5a55b
Step 16/16 : CMD ["rqlited", "-http-addr", "0.0.0.0:4001", "-raft-addr", "0.0.0.0:4002", "/rqlite/file/data"]
 ---> Running in 8a3aaa1392b0
Removing intermediate container 8a3aaa1392b0
 ---> 27013790404a
Successfully built 27013790404a
Successfully tagged rqlite/rqlite-alpine:4.2.2

```