### PR TITLE
use docker v20 circleci and buildx

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,9 @@
+- setup_remote_docker:
+    version: 20.10.11
+- run:
+    name: Create a new docker buildx builder instance
+    command: |
+      docker run --privileged --rm tonistiigi/binfmt --install all
+      docker context create multiarch-builder
+      docker buildx create --use multiarch-builder
+

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -5,7 +5,7 @@ To build and push a new Docker image, of the release x.y.z, first create the cor
 ```
 export VERSION=x.y.z
 cd $VERSION
-docker build -t rqlite/rqlite:$VERSION .
+docker buildx -t rqlite/rqlite:$VERSION .
 docker push rqlite/rqlite:$VERSION
 ```
 To update the `latest` tag, execute the same instructions but pass `latest` instead `x.y.z`.


### PR DESCRIPTION
This attempts to try and start building rqlite docker image with multi-architecture support. This will be great for things like kuberentes where you can have the same image used on different architecture types.